### PR TITLE
Update for Sitecore 10.1

### DIFF
--- a/CacheManager.aspx
+++ b/CacheManager.aspx
@@ -5,15 +5,17 @@
 <%@ Import Namespace="Sitecore.Configuration"%>
 <%@ Import Namespace="Sitecore.Diagnostics"%>
 <%@ Import Namespace="Sitecore.sitecore.admin"%>
+<%@ Import Namespace="Sitecore.Abstractions"%>
 <%@ Import Namespace="System"%>
 <%@ Import Namespace="System.Collections"%>
 <%@ Import Namespace="System.Collections.Generic"%>
 <%@ Import Namespace="System.Linq"%>
 <%@ Import Namespace="System.Web.UI.WebControls"%>
 
+
 <script runat="server">
     #region Admin Page 
-        
+
     private bool IsDeveloper {
         get {
             if (!this.User.IsInRole("sitecore\\developer"))
@@ -35,11 +37,11 @@
             return;
         this.Response.Redirect(string.Format("{0}?returnUrl={1}", (object)site.LoginPage, (object)HttpUtility.UrlEncode(this.Request.Url.PathAndQuery)));
     }
-        
+
     #endregion Admin Page 
 
     #region Page Events
-    
+
     protected override void OnInit(EventArgs arguments) {
         Assert.ArgumentNotNull((object)arguments, "arguments");
         this.CheckSecurity(true);
@@ -56,9 +58,9 @@
         List<string> SystemSiteNames = new List<string>() { "admin", "login", "modules_shell", "modules_website", "publisher", "scheduler", "service", "shell", "system", "website" };
         SetupChecklist(cblSysSiteNames, SystemSiteNames);
         //site names
-        SetupChecklist(cblSiteNames, Factory.GetSiteNames().Where(a => !SystemSiteNames.Contains(a)).OrderBy(a => a).ToList());
+        SetupChecklist(cblSiteNames, SiteContextFactory.GetSiteNames().ToList());
         //site types
-        SetupChecklist(cblSiteTypes, new List<string>() { "[filtered items]", "[html]", "[registry]", "[viewstate]", "[xsl]" });
+        SetupChecklist(cblSiteTypes, new List<string>() { "[filtered items]", "[html]", "[partial html]","[registry]", "[viewstate]", "[xsl]" });
         //db types			
         SetupChecklist(cblDBTypes, new List<string>() { "[blobIDs]", "[data]", "[items]", "[itempaths]", "[paths]", "[standardValues]" });
         //db names
@@ -202,9 +204,10 @@
         IEnumerable<Sitecore.Caching.ICacheInfo> allCaches = CacheManager.GetAllCaches().OrderBy(a => a.Name);
 
         string query = txtGQuery.Text.ToLower();
-        foreach (Sitecore.Caching.ICache c in allCaches) {
+        foreach (Sitecore.Caching.ICacheInfo c in allCaches) {
             try {
-                foreach (string s in c.GetCacheKeys()) {
+				var cc = Sitecore.Caching.CacheManager.FindCacheByName<string>(c.Name) as ICache;
+                foreach (string s in cc.GetCacheKeys()) {
                     if (s.ToLower().Contains(query)) {
                         qr.Add(new ListItem(c.Name, s));
                     }
@@ -320,8 +323,8 @@
     protected List<Sitecore.Caching.ICache> GetCachesByNames(List<string> names) {
 
         List<Sitecore.Caching.ICache> returnCaches = new List<Sitecore.Caching.ICache>();
-        foreach (string s in names) {
-            Sitecore.Caching.ICache c = CacheManager.FindCacheByName(s);
+        foreach (string s in names) {	
+            Sitecore.Caching.ICache c = Sitecore.Caching.CacheManager.FindCacheByName<string>(s) as ICache;
             if (c != null) {
                 returnCaches.Add(c);
             }
@@ -429,7 +432,7 @@
                     .btn input:hover,
                     .btn a:hover { text-decoration:underline; }
 	</style>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="/sitecore/shell/client/Speak/Assets/lib/ui/2.0/deps/jquery-2.1.1.min.js"></script>
     <script type="text/javascript">
     	$(document).ready(function () {
     		var allTabs = ".normalTab, .activeTab";
@@ -494,8 +497,8 @@
     <form id="form1" defaultbutton="btnGQuery" runat="server">
 		<asp:ScriptManager ID="scriptManager" runat="server"></asp:ScriptManager>
 		<script type="text/javascript" language="javascript">
-			Sys.WebForms.PageRequestManager.getInstance().add_beginRequest(beginRequest);
-			Sys.WebForms.PageRequestManager.getInstance().add_endRequest(endRequest);
+            Sys.WebForms.PageRequestManager.getInstance().add_beginRequest(beginRequest);
+            Sys.WebForms.PageRequestManager.getInstance().add_endRequest(endRequest);
         </script>
 		<h1>Caching Manager</h1>
 		<div id="EditorTabs">

--- a/CacheManager.aspx
+++ b/CacheManager.aspx
@@ -553,18 +553,41 @@
             }
             else
             {
-                var sc = Sitecore.Caching.CacheManager.FindCacheByName<string>(s);
-                if (sc != null)
+                try
                 {
-                    if (clear)
+                    var sc = Sitecore.Caching.CacheManager.FindCacheByName<string>(s);
+                    if (sc != null)
                     {
-                        sc.Clear();
+                        if (clear)
+                        {
+                            sc.Clear();
+                        }
+                        c.Name = sc.Name;
+                        c.Size = sc.Size;
+                        c.MaxSize = sc.MaxSize;
+                        c.Count = sc.Count;
+                        if (includeKeys) c.Keys = sc.GetCacheKeys();
                     }
-                    c.Name = sc.Name;
-                    c.Size = sc.Size;
-                    c.MaxSize = sc.MaxSize;
-                    c.Count = sc.Count;
-                    if (includeKeys) c.Keys = sc.GetCacheKeys();
+                } catch (Exception ex)
+                {
+                    //perhaps a unknow user cache or a bew one.
+                    var scInfo = Sitecore.Caching.CacheManager.GetAllCaches().FirstOrDefault(x => x.Name == s);
+                    if (scInfo != null)
+                    {
+                        if (clear)
+                        {
+                            scInfo.Clear();
+                        }
+                        c.Name = scInfo.Name;
+                        c.Size = scInfo.Size;
+                        c.MaxSize = scInfo.MaxSize;
+                        c.Count = scInfo.Count;
+                        if (includeKeys)
+                        {
+                            //not implemented due to unknow
+                            c.Keys = new string[1] { "not implemented unknown not string cache key"};
+                        }
+                    }
                 }
             }
 

--- a/CacheManager.aspx
+++ b/CacheManager.aspx
@@ -129,24 +129,29 @@
 
     protected void FetchARCacheProfile(object sender, EventArgs e) {
 
-        rptARCacheProfiles.DataSource = GetCachesByNames(GetSelectedItemValues(cblAccessResult.Items));
+        rptARCacheProfiles.DataSource = GetACCachesByNames(GetSelectedItemValues(cblAccessResult.Items));
         rptARCacheProfiles.DataBind();
     }
 
     protected void ClearARCacheProfile(object sender, EventArgs e) {
-
-        List<Sitecore.Caching.ICache> list = GetCachesByNames(GetSelectedItemValues(cblAccessResult.Items));
-        ClearCaches(list);
-        rptARCaches.DataSource = list;
+		var ac = Sitecore.Caching.CacheManager.GetAccessResultCache();
+		ac.Clear();
+        rptARCaches.DataSource = GetACCachesByNames(GetSelectedItemValues(cblAccessResult.Items));;
         rptARCaches.DataBind();
     }
 
     protected void FetchARCacheList(object sender, EventArgs e) {
 
-        rptARCaches.DataSource = GetCachesByNames(GetSelectedItemValues(cblAccessResult.Items));
+        rptARCaches.DataSource = GetACCachesByNames(GetSelectedItemValues(cblAccessResult.Items));
         rptARCaches.DataBind();
     }
 
+	protected List<Sitecore.Caching.Generics.ICache<AccessResultCacheKey>> GetACCachesByNames(List<string> names) {
+		var ac = Sitecore.Caching.CacheManager.GetAccessResultCache();
+        List<Sitecore.Caching.Generics.ICache<AccessResultCacheKey>> returnCaches = new List<Sitecore.Caching.Generics.ICache<AccessResultCacheKey>>();
+        returnCaches.Add(ac.InnerCache);
+        return returnCaches;
+    }
     #endregion Access Result
 
     #region Providers
@@ -259,6 +264,15 @@
     protected void rptSCProfiles_DataBound(object sender, RepeaterItemEventArgs e) {
         Repeater rptBySite = (Repeater)e.Item.FindControl("rptBySite");
         Sitecore.Caching.ICache cacheItem = (Sitecore.Caching.ICache)e.Item.DataItem;
+        if (rptBySite == null)
+            return;
+        rptBySite.DataSource = cacheItem.GetCacheKeys();
+        rptBySite.DataBind();
+    }
+
+	protected void rptSCACProfiles_DataBound(object sender, RepeaterItemEventArgs e) {
+        Repeater rptBySite = (Repeater)e.Item.FindControl("rptBySite");
+        Sitecore.Caching.Generics.Cache<AccessResultCacheKey> cacheItem = (Sitecore.Caching.Generics.Cache<AccessResultCacheKey>)e.Item.DataItem;
         if (rptBySite == null)
             return;
         rptBySite.DataSource = cacheItem.GetCacheKeys();
@@ -864,10 +878,10 @@
 							</HeaderTemplate>
 							<ItemTemplate>
 								<div class="FormRow <%# GetClass(Container.ItemIndex) %>">
-									<div class="Name RowValue"><%# ((Sitecore.Caching.ICache)Container.DataItem).Name %></div>
-									<div class="Count RowValue"><%# ((Sitecore.Caching.ICache)Container.DataItem).Count %></div>
-									<div class="Size RowValue"><%# GetValFromB(((Sitecore.Caching.ICache)Container.DataItem).Size) %></div>
-									<div class="MaxSize RowValue"><%# GetValFromB(((Sitecore.Caching.ICache)Container.DataItem).MaxSize) %></div>
+									<div class="Name RowValue"><%# ((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).Name %></div>
+									<div class="Count RowValue"><%# ((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).Count %></div>
+									<div class="Size RowValue"><%# GetValFromB(((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).Size) %></div>
+									<div class="MaxSize RowValue"><%# GetValFromB(((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).MaxSize) %></div>
 									<div class="clear"></div>
 								</div>	
 							</ItemTemplate>
@@ -875,15 +889,15 @@
 						</asp:Repeater>
 						</div>
 						<div class="ProfileList ARProfileList">
-							<asp:Repeater ID="rptARCacheProfiles" OnItemDataBound="rptSCProfiles_DataBound" runat="server">
+							<asp:Repeater ID="rptARCacheProfiles" OnItemDataBound="rptSCACProfiles_DataBound" runat="server">
 								<HeaderTemplate><div class="Results"></HeaderTemplate>
 								<ItemTemplate>
 									<div class="FormRow">
-										<h3><%# ((Sitecore.Caching.ICache)Container.DataItem).Name %> - 
-											<span>Cache Entries:</span> <span class="title"><%# ((Sitecore.Caching.ICache)Container.DataItem).Count %></span>
-											<span>Size:</span> <span class="title"><%# GetValFromB(((Sitecore.Caching.ICache)Container.DataItem).Size) %></span>
-											<span>MaxSize:</span> <span class="title"><%# GetValFromB(((Sitecore.Caching.ICache)Container.DataItem).MaxSize) %></span>
-										</h4>
+										<h3><%# ((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).Name %> - 
+											<span>Cache Entries:</span> <span class="title"><%# ((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).Count %></span>
+											<span>Size:</span> <span class="title"><%# GetValFromB(((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).Size) %></span>
+											<span>MaxSize:</span> <span class="title"><%# GetValFromB(((Sitecore.Caching.Generics.ICache<AccessResultCacheKey>)Container.DataItem).MaxSize) %></span>
+										</h3>
 										<div class="CacheItems">
 											<asp:Repeater ID="rptBySite" runat="server">
 												<HeaderTemplate>
@@ -894,7 +908,7 @@
 												</HeaderTemplate>
 												<ItemTemplate>
 													<div class="FormRow <%# GetClass(Container.ItemIndex) %>">
-														<div class="CacheID"><%# Container.DataItem %></div>
+														<div class="CacheID"><%# ((AccessResultCacheKey)Container.DataItem).EntityId %></div>
 													</div>
 												</ItemTemplate>
 											</asp:Repeater>

--- a/CacheManager.aspx
+++ b/CacheManager.aspx
@@ -570,7 +570,7 @@
                     }
                 } catch (Exception ex)
                 {
-                    //perhaps a unknow user cache or a bew one.
+                    //perhaps a unknow user cache or a new one.
                     var scInfo = Sitecore.Caching.CacheManager.GetAllCaches().FirstOrDefault(x => x.Name == s);
                     if (scInfo != null)
                     {
@@ -812,7 +812,7 @@
                                 </div>
                                 <div class="btnSpacer">.</div>
                                 <div class="btn">
-                                    <asp:Button ID="btnGQueryClear" rel=".GlobalRegion" CssClass="BtnClear" Text="Clear Search Results" runat="server" OnClick="btnGQueryClear_Click" />
+                                    <asp:Button ID="btnGQueryClear" rel=".GlobalRegion" CssClass="BtnClear" Text="Clear Search Results" runat="server" OnClick="btnGQueryClear_Click" Title="(currently works only for Caches with string type key)"/>
                                 </div>
                                 <div class="btnSpacer">.</div>
                                 <div class="btn">

--- a/CacheManager.aspx
+++ b/CacheManager.aspx
@@ -474,7 +474,7 @@
                     }
                 }
             }
-            else if (s == "ExperienceAnalytics.DimensionItems" || s == "DeviceDictionaryCache" || s == "GeoIpDataDictionaryCache")
+            else if (s == "ExperienceAnalytics.DimensionItems" || s == "DeviceDictionaryCache" || s == "GeoIpDataDictionaryCache" || s == "LocationsDictionaryCache")
             {
                 var dc = Sitecore.Caching.CacheManager.FindCacheByName<System.Guid>(s);
                 if (dc != null)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# SitecoreCachingManager
+Console for easy Sitecore cache management
+For Sitecore 10+ (see history for older versions)
+
+Features
+-Search in the cache keys from All Sitecore caches.
+-Delete a cache entry found with a search.
+-Get all cache keys from the selected Sitecore caches.
+-Clear the Selected Sitecotre caches.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SitecoreCachingManager
 Console for easy Sitecore cache management
-For Sitecore 10+ (see history for older versions)
+For Sitecore 10+ (backwards compatible with Sitecore 9.x see history for older versions)
 
 Features
 - Search in the cache keys from All Sitecore caches.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Console for easy Sitecore cache management
 For Sitecore 10+ (see history for older versions)
 
 Features
--Search in the cache keys from All Sitecore caches.
--Delete a cache entry found with a search.
--Get all cache keys from the selected Sitecore caches.
--Clear the Selected Sitecotre caches.
+- Search in the cache keys from All Sitecore caches.
+- Delete a cache entry found with a search.
+- Get all cache keys from the selected Sitecore caches.
+- Clear the Selected Sitecore caches.
+
+Place this file "cachemanager.aspx" in the webroot below Sitecore/admin/ folder and access in web browser with /sitecore/admin/cachemanager.aspx requires Sitecore administrator or developer rights. 


### PR DESCRIPTION
Caching has changed a bit from 10 years ago not only string keys anymore and also loading an external jquery.js is restricted, better to use internal jquery. unfortunately perhaps breaking changes no support for Sitecore 8  anymore, but now with all new 10.1 caches like the [partial html] looks like it is also working for Sitecore 9.0 - 9.3